### PR TITLE
Add scrolling to details UI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -82,6 +82,7 @@ pub struct App {
     pub read_items: Vec<String>, // Track read item IDs
     pub filtered_dashboard_items: Vec<(usize, usize)>, // Filtered items for dashboard
     pub category_action: Option<CategoryAction>, // For category management
+    pub detail_vertical_scroll: u16, // Vertical scroll value for item detail view
 }
 
 #[derive(Clone, Debug)]
@@ -134,6 +135,7 @@ impl App {
             read_items: saved_data.read_items,
             filtered_dashboard_items: Vec::new(),
             category_action: None,
+            detail_vertical_scroll: 0,
         };
 
         // Load bookmarked feeds

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -387,6 +387,8 @@ fn handle_events(app: &mut App) -> Result<bool> {
                 View::FeedItemDetail => match key.code {
                     KeyCode::Char('q') => return Ok(true),
                     KeyCode::Esc | KeyCode::Char('h') | KeyCode::Backspace => {
+                        // Reset detail scroll to top when leaving.
+                        app.detail_vertical_scroll = 0;
                         if app.is_searching {
                             // Return to search results
                             app.view = View::Dashboard;
@@ -399,6 +401,14 @@ fn handle_events(app: &mut App) -> Result<bool> {
                     KeyCode::Home => {
                         app.view = View::Dashboard;
                         app.selected_item = None;
+                        // Reset detail scroll to top when leaving.
+                        app.detail_vertical_scroll = 0;
+                    }
+                    KeyCode::Up => {
+                        app.detail_vertical_scroll = app.detail_vertical_scroll.saturating_sub(1);
+                    }
+                    KeyCode::Down => {
+                        app.detail_vertical_scroll = app.detail_vertical_scroll.saturating_add(1);
                     }
                     KeyCode::Char('r') => {
                         // Set loading flag before starting refresh

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -948,6 +948,7 @@ fn render_item_detail<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
                     .padding(Padding::new(1, 1, 1, 1)),
             )
             .style(Style::default().fg(TEXT_COLOR))
+            .scroll((app.detail_vertical_scroll, 0))
             .wrap(Wrap { trim: true });
 
         f.render_widget(content, chunks[1]);
@@ -980,7 +981,7 @@ fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
                     "h/esc: back to feeds | home: dashboard | enter: view detail | o: open link | /: search | q: quit"
                 }
                 View::FeedItemDetail => {
-                    "h/esc: back | home: dashboard | o: open in browser | q: quit"
+                    "h/esc: back | home: dashboard | o: open in browser | ↑/↓: scroll | q: quit"
                 }
             };
             (help_text, Style::default().fg(TEXT_COLOR))


### PR DESCRIPTION
Hi, thanks for your work on feedr! I've been having a great time playing around with it. I kind of gave up on RSS feeds after Google killed Reader, but your project has rekindled my interest in feeds again.

I noticed that some of the feeds on the details page get truncated in the Paragraph widget, so I hacked together a way to scroll down so that I can keep reading content in feedr without having to open a browser window. Unfortunately, it's kind of a hack, and will let you scroll right past the end of the content and keep going all the way to `u16::MAX`. I looked around to see if `Paragraph` could give me some length hint or state that I could use to stop the scrolling at the end of the content, but all I could find was this:

https://github.com/ratatui/ratatui/issues/136

which doesn't look too promising. I'm fairly new at TUI programming so I thought I'd send this PR out as a starting point for discussion. I'd really like to get scrolling working properly!