### PR TITLE
feat: Add mark as read/unread toggle with animated notifications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -75,6 +75,8 @@ pub struct App {
     pub selected_item: Option<usize>,
     pub view: View,
     pub error: Option<String>,
+    pub success_message: Option<String>,
+    pub success_message_time: Option<Instant>,
     pub search_query: String,
     pub is_searching: bool,
     pub filtered_items: Vec<(usize, usize)>, // (feed_idx, item_idx) for search results
@@ -139,6 +141,8 @@ impl App {
             selected_item: None,
             view: View::Dashboard,
             error: None,
+            success_message: None,
+            success_message_time: None,
             search_query: String::new(),
             is_searching: false,
             filtered_items: Vec::new(),
@@ -396,6 +400,27 @@ impl App {
             self.save_data()?;
         }
         Ok(())
+    }
+
+    // Toggle an item's read status and return whether it's now read
+    pub fn toggle_item_read(&mut self, feed_idx: usize, item_idx: usize) -> Result<bool> {
+        let item_id = self.get_item_id(feed_idx, item_idx);
+        if !item_id.is_empty() {
+            let is_now_read =
+                if let Some(pos) = self.read_items.iter().position(|id| id == &item_id) {
+                    // Item is read, mark as unread
+                    self.read_items.remove(pos);
+                    false
+                } else {
+                    // Item is unread, mark as read
+                    self.read_items.push(item_id);
+                    true
+                };
+            self.save_data()?;
+            Ok(is_now_read)
+        } else {
+            Ok(false)
+        }
     }
 
     // Check if an item is read

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -62,6 +62,11 @@ pub fn render<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         render_error_modal(f, error);
     }
 
+    // Show success notification if present
+    if let Some(success) = &app.success_message {
+        render_success_notification(f, success);
+    }
+
     // Show input modal when in input modes
     if matches!(app.input_mode, InputMode::InsertUrl | InputMode::SearchMode) {
         render_input_modal(f, app);
@@ -984,7 +989,7 @@ fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
                     if app.feeds.is_empty() {
                         "a: Add feed | q: Quit | CTRL+C: Manage categories"
                     } else {
-                        "↑/↓: Navigate | ENTER: View feed | a: Add feed | r: Refresh | f: Filter | /: Search | q: Quit"
+                        "↑/↓: Navigate | ENTER: View | Space: Toggle read | a: Add feed | r: Refresh | f: Filter | /: Search | q: Quit"
                     }
                 }
                 View::FeedList => {
@@ -998,10 +1003,10 @@ fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
                     "n: New category | e: Edit | d: Delete | SPACE: Toggle feeds | c: Add selected feed | ESC/q: Back"
                 }
                 View::FeedItems => {
-                    "h/esc: back to feeds | home: dashboard | enter: view detail | o: open link | /: search | q: quit"
+                    "h/esc: back | home: dashboard | enter: view | Space: Toggle read | o: open | /: search | q: quit"
                 }
                 View::FeedItemDetail => {
-                    "h/esc: back | home: dashboard | ↑/↓: scroll | PgUp/PgDn: fast scroll | g: top | G/End: bottom | o: open | q: quit"
+                    "h/esc: back | home: dashboard | ↑/↓: scroll | PgUp/PgDn: fast | Space: Toggle read | o: open | q: quit"
                 }
             };
             (help_text, Style::default().fg(TEXT_COLOR))
@@ -1100,6 +1105,37 @@ fn render_error_modal<B: Backend>(f: &mut Frame<B>, error: &str) {
         .wrap(Wrap { trim: true });
 
     f.render_widget(error_text, area);
+}
+
+fn render_success_notification<B: Backend>(f: &mut Frame<B>, message: &str) {
+    // Create a smaller notification in the top-right corner
+    let area = Rect {
+        x: f.size().width.saturating_sub(42),
+        y: 2,
+        width: 40.min(f.size().width),
+        height: 3,
+    };
+
+    // Clear the background
+    f.render_widget(Clear, area);
+
+    // Create an attractive success notification
+    let success_text = Paragraph::new(Line::from(vec![Span::styled(
+        format!("  {}  ", message),
+        Style::default()
+            .fg(HIGHLIGHT_COLOR)
+            .add_modifier(Modifier::BOLD),
+    )]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(HIGHLIGHT_COLOR))
+            .style(Style::default().bg(Color::Rgb(20, 40, 30))), // Dark green background
+    )
+    .alignment(Alignment::Center);
+
+    f.render_widget(success_text, area);
 }
 
 fn render_input_modal<B: Backend>(f: &mut Frame<B>, app: &App) {


### PR DESCRIPTION
- Add toggle_item_read() method to toggle read/unread status
- Implement Space key handler in Dashboard, FeedItems, and Detail views
- Auto-mark items as read when viewing detail page
- Add animated success notification in top-right corner
- Success messages auto-dismiss after 1.5 seconds
- Display ✓ for marked as read, ○ for marked as unread
- Update help text to show Space key functionality

Closes #8