### PR TITLE
Add missing Vim Motions to the Categories page

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -653,7 +653,7 @@ fn handle_events(app: &mut App) -> Result<bool> {
                                 }
                             }
                         }
-                        KeyCode::Up => {
+                        KeyCode::Up | KeyCode::Char('k') => {
                             // Select previous category
                             if let Some(selected) = app.selected_category {
                                 if selected > 0 {
@@ -663,7 +663,7 @@ fn handle_events(app: &mut App) -> Result<bool> {
                                 app.selected_category = Some(0);
                             }
                         }
-                        KeyCode::Down => {
+                        KeyCode::Down | KeyCode::Char('j') => {
                             // Select next category
                             if let Some(selected) = app.selected_category {
                                 if selected < app.categories.len() - 1 {


### PR DESCRIPTION
I noticed that the categories page was missing the keybindings for J and K to navigate up and down, so I added them.