### PR TITLE
Implement Press any Key to Dismiss

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -103,6 +103,7 @@ fn handle_events(app: &mut App) -> Result<bool> {
         if matches!(key.kind, KeyEventKind::Release) {
             return Ok(false);
         }
+        app.error = None;
         match app.input_mode {
             InputMode::Normal => match app.view {
                 View::Dashboard => match key.code {


### PR DESCRIPTION
Hey I'm brand new to this app & I'm loving it so far, but one thing I noticed when trying to learn some of the key bindings (and getting a lot of errors) is that the error popup only went away after patiently waiting for a minute. This is a tall order. The help message suggests that pressing any key should make the errors go away, so I figured that is the desired behavior.

It seemed like a small fix so I figured I'd just throw it up here & see what y'all think. 