### PR TITLE
fix: defer feed loading for instant TUI startup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -128,6 +128,8 @@ impl App {
             read_items: vec![],
         });
 
+        let has_bookmarks = !saved_data.bookmarks.is_empty();
+
         let mut app = Self {
             config,
             feeds: Vec::new(),
@@ -146,7 +148,7 @@ impl App {
             is_searching: false,
             filtered_items: Vec::new(),
             dashboard_items: Vec::new(),
-            is_loading: false,
+            is_loading: has_bookmarks,
             loading_indicator: 0,
             filter_options: FilterOptions::new(),
             filter_mode: false,
@@ -160,8 +162,6 @@ impl App {
             last_domain_fetch: HashMap::new(),
         };
 
-        // Load bookmarked feeds
-        app.load_bookmarked_feeds();
         app.update_dashboard();
 
         app
@@ -169,12 +169,34 @@ impl App {
 
     pub fn load_bookmarked_feeds(&mut self) {
         self.feeds.clear();
+        if self.bookmarks.is_empty() {
+            return;
+        }
+
         let timeout = self.config.network.http_timeout;
-        let user_agent = &self.config.network.user_agent;
-        for url in &self.bookmarks {
-            match Feed::from_url_with_config(url, timeout, Some(user_agent)) {
-                Ok(feed) => self.feeds.push(feed),
-                Err(_) => { /* Skip failed feeds */ }
+        let user_agent = self.config.network.user_agent.clone();
+
+        let client = match Feed::build_client(timeout) {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        // Spawn a thread per bookmark URL for parallel fetching
+        let handles: Vec<_> = self
+            .bookmarks
+            .iter()
+            .map(|url| {
+                let client = client.clone();
+                let url = url.clone();
+                let ua = user_agent.clone();
+                std::thread::spawn(move || Feed::from_url_with_client(&url, &client, Some(&ua)))
+            })
+            .collect();
+
+        // Collect results in original bookmark order
+        for handle in handles {
+            if let Ok(Ok(feed)) = handle.join() {
+                self.feeds.push(feed);
             }
         }
     }
@@ -638,26 +660,74 @@ impl App {
 
         let timeout = self.config.network.http_timeout;
         let user_agent = self.config.network.user_agent.clone();
+        let rate_limit_delay = self.config.general.refresh_rate_limit_delay;
+
+        // Pre-calculate per-domain delays before spawning threads
+        let domain_delays: HashMap<String, std::time::Duration> = domain_groups
+            .keys()
+            .map(|domain| (domain.clone(), self.calculate_required_delay(domain)))
+            .collect();
+
         self.feeds.clear();
 
-        // Process each domain group with rate limiting
-        for (domain, urls) in domain_groups {
-            // Calculate and apply required delay for this domain
-            let delay = self.calculate_required_delay(&domain);
-            if !delay.is_zero() {
-                std::thread::sleep(delay);
+        let client = match Feed::build_client(timeout) {
+            Ok(c) => c,
+            Err(e) => {
+                self.is_loading = false;
+                self.refresh_in_progress = false;
+                return Err(e);
             }
+        };
 
-            // Fetch all feeds from this domain
-            for url in &urls {
-                match Feed::from_url_with_config(url, timeout, Some(&user_agent)) {
-                    Ok(feed) => self.feeds.push(feed),
-                    Err(e) => self.error = Some(format!("Failed to refresh feed {}: {}", url, e)),
+        // Spawn one thread per domain group — domains fetch in parallel,
+        // feeds within the same domain fetch sequentially (rate limiting)
+        let handles: Vec<_> = domain_groups
+            .into_iter()
+            .map(|(domain, urls)| {
+                let client = client.clone();
+                let ua = user_agent.clone();
+                let delay = domain_delays.get(&domain).copied().unwrap_or_default();
+                let rate_limit = std::time::Duration::from_millis(rate_limit_delay);
+
+                std::thread::spawn(move || {
+                    if !delay.is_zero() {
+                        std::thread::sleep(delay);
+                    }
+
+                    let mut results = Vec::new();
+                    for (i, url) in urls.iter().enumerate() {
+                        // Rate-limit between feeds on the same domain
+                        if i > 0 && !rate_limit.is_zero() {
+                            std::thread::sleep(rate_limit);
+                        }
+                        results.push((
+                            url.clone(),
+                            Feed::from_url_with_client(url, &client, Some(&ua)),
+                        ));
+                    }
+                    (domain, results)
+                })
+            })
+            .collect();
+
+        // Collect results and update domain fetch times
+        let mut errors = Vec::new();
+        for handle in handles {
+            if let Ok((domain, results)) = handle.join() {
+                for (url, result) in results {
+                    match result {
+                        Ok(feed) => self.feeds.push(feed),
+                        Err(e) => {
+                            errors.push(format!("Failed to refresh feed {}: {}", url, e));
+                        }
+                    }
                 }
+                self.last_domain_fetch.insert(domain, Instant::now());
             }
+        }
 
-            // Update the last fetch time for this domain
-            self.last_domain_fetch.insert(domain, Instant::now());
+        if let Some(last_error) = errors.last() {
+            self.error = Some(last_error.clone());
         }
 
         self.update_dashboard();

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -83,15 +83,28 @@ impl Feed {
         timeout_secs: u64,
         user_agent: Option<&str>,
     ) -> Result<Self> {
-        let default_user_agent =
-            "Mozilla/5.0 (compatible; Feedr/1.0; +https://github.com/bahdotsh/feedr)";
-        let ua = user_agent.unwrap_or(default_user_agent);
+        let client = Self::build_client(timeout_secs)?;
+        Self::from_url_with_client(url, &client, user_agent)
+    }
 
-        let client = reqwest::blocking::Client::builder()
+    /// Build a shared HTTP client with the given timeout
+    pub fn build_client(timeout_secs: u64) -> Result<reqwest::blocking::Client> {
+        reqwest::blocking::Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
             .timeout(Duration::from_secs(timeout_secs))
             .build()
-            .context("Failed to create HTTP client")?;
+            .context("Failed to create HTTP client")
+    }
+
+    /// Fetch and parse a feed from a URL using a pre-built client
+    pub fn from_url_with_client(
+        url: &str,
+        client: &reqwest::blocking::Client,
+        user_agent: Option<&str>,
+    ) -> Result<Self> {
+        let default_user_agent =
+            "Mozilla/5.0 (compatible; Feedr/1.0; +https://github.com/bahdotsh/feedr)";
+        let ua = user_agent.unwrap_or(default_user_agent);
 
         let response = client
             .get(url)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,5 @@
 use crate::app::{App, CategoryAction, InputMode, TimeFilter, View};
+use crate::feed::Feed;
 use crate::ui;
 use anyhow::Result;
 use crossterm::{
@@ -12,6 +13,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     Terminal,
 };
+use std::sync::mpsc;
 use std::{io, time::Duration};
 
 pub fn run(mut app: App) -> Result<()> {
@@ -47,8 +49,64 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<()> 
     let tick_rate = Duration::from_millis(app.config.ui.tick_rate);
     let error_timeout = Duration::from_millis(app.config.ui.error_display_timeout);
 
+    // Spawn background threads to load bookmarked feeds
+    let mut pending_count: usize = 0;
+    let (feed_tx, feed_rx) = mpsc::channel::<(usize, Result<Feed>)>();
+
+    if !app.bookmarks.is_empty() {
+        let timeout = app.config.network.http_timeout;
+        let user_agent = app.config.network.user_agent.clone();
+
+        if let Ok(client) = Feed::build_client(timeout) {
+            pending_count = app.bookmarks.len();
+            for (idx, url) in app.bookmarks.iter().enumerate() {
+                let client = client.clone();
+                let url = url.clone();
+                let ua = user_agent.clone();
+                let tx = feed_tx.clone();
+                std::thread::spawn(move || {
+                    let result = Feed::from_url_with_client(&url, &client, Some(&ua));
+                    let _ = tx.send((idx, result));
+                });
+            }
+        } else {
+            app.is_loading = false;
+        }
+    }
+    // Drop our copy so the channel closes when all threads finish
+    drop(feed_tx);
+
     loop {
         terminal.draw(|f| ui::render(f, app))?;
+
+        // Drain any feeds that arrived from background threads
+        if pending_count > 0 {
+            while let Ok((idx, result)) = feed_rx.try_recv() {
+                if let Ok(feed) = result {
+                    // Insert at the correct position to maintain bookmark order,
+                    // or append if earlier feeds haven't arrived yet
+                    let insert_pos = app
+                        .feeds
+                        .iter()
+                        .position(|f| {
+                            app.bookmarks
+                                .iter()
+                                .position(|b| b == &f.url)
+                                .unwrap_or(usize::MAX)
+                                > idx
+                        })
+                        .unwrap_or(app.feeds.len());
+                    app.feeds.insert(insert_pos, feed);
+                    app.update_dashboard();
+                }
+                pending_count -= 1;
+                if pending_count == 0 {
+                    app.is_loading = false;
+                    app.last_refresh = Some(std::time::Instant::now());
+                    app.update_dashboard();
+                }
+            }
+        }
 
         // If loading, use a shorter timeout for animation
         let timeout = if app.is_loading {


### PR DESCRIPTION
Move feed loading out of `App::new()` and into background threads spawned after the TUI starts rendering. Uses `std::sync::mpsc` to send results back to the main loop, which drains them each tick and inserts feeds in bookmark order. The existing `is_loading`/`loading` indicator now shows during initial load. Also parallelizes `load_bookmarked_feeds()` and `refresh_feeds()` with per-domain rate limiting.