### PR TITLE
feat: add starred/saved articles with dedicated view and filtering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,11 +11,12 @@ use std::time::Instant;
 
 #[derive(Clone, Debug, Default)]
 pub struct FilterOptions {
-    pub category: Option<String>,  // Filter by feed category
-    pub age: Option<TimeFilter>,   // Filter by content age
-    pub has_author: Option<bool>,  // Filter for items with/without author
-    pub read_status: Option<bool>, // Filter for read/unread items
-    pub min_length: Option<usize>, // Filter by content length
+    pub category: Option<String>,   // Filter by feed category
+    pub age: Option<TimeFilter>,    // Filter by content age
+    pub has_author: Option<bool>,   // Filter for items with/without author
+    pub read_status: Option<bool>,  // Filter for read/unread items
+    pub min_length: Option<usize>,  // Filter by content length
+    pub starred_only: Option<bool>, // Filter for starred/unstarred items
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -37,6 +38,7 @@ impl FilterOptions {
             || self.has_author.is_some()
             || self.read_status.is_some()
             || self.min_length.is_some()
+            || self.starred_only.is_some()
     }
 
     pub fn reset(&mut self) {
@@ -61,6 +63,7 @@ pub enum View {
     FeedItemDetail,
     CategoryManagement,
     Summary,
+    Starred,
 }
 
 #[derive(Clone, Debug)]
@@ -87,6 +90,7 @@ pub struct App {
     pub filter_options: FilterOptions,
     pub filter_mode: bool,           // Whether we're in filter selection mode
     pub read_items: HashSet<String>, // Track read item IDs
+    pub starred_items: HashSet<String>, // Track starred item IDs
     pub filtered_dashboard_items: Vec<(usize, usize)>, // Filtered items for dashboard
     pub category_action: Option<CategoryAction>, // For category management
     pub detail_vertical_scroll: u16, // Vertical scroll value for item detail view
@@ -116,6 +120,8 @@ struct SavedData {
     categories: Vec<FeedCategory>,
     read_items: HashSet<String>,
     #[serde(default)]
+    starred_items: HashSet<String>,
+    #[serde(default)]
     last_session_time: Option<String>,
 }
 
@@ -137,6 +143,7 @@ impl App {
             bookmarks: vec![],
             categories: vec![],
             read_items: HashSet::new(),
+            starred_items: HashSet::new(),
             last_session_time: None,
         });
 
@@ -175,6 +182,7 @@ impl App {
             filter_options: FilterOptions::new(),
             filter_mode: false,
             read_items: saved_data.read_items,
+            starred_items: saved_data.starred_items,
             filtered_dashboard_items: Vec::new(),
             category_action: None,
             detail_vertical_scroll: 0,
@@ -237,6 +245,7 @@ impl App {
                 bookmarks: Vec::new(),
                 categories: Vec::new(),
                 read_items: HashSet::new(),
+                starred_items: HashSet::new(),
                 last_session_time: None,
             });
         }
@@ -256,6 +265,7 @@ impl App {
             bookmarks: self.bookmarks.clone(),
             categories: self.categories.clone(),
             read_items: self.read_items.clone(),
+            starred_items: self.starred_items.clone(),
             last_session_time: Some(Utc::now().to_rfc3339()),
         };
 
@@ -414,6 +424,15 @@ impl App {
             }
         }
 
+        // Check starred status filter
+        if let Some(is_starred) = self.filter_options.starred_only {
+            let item_id = self.get_item_id(feed_idx, item_idx);
+            let item_is_starred = self.starred_items.contains(&item_id);
+            if is_starred != item_is_starred {
+                return false;
+            }
+        }
+
         // Check content length filter using cached plain_text (avoids HTML parsing)
         if let Some(min_length) = self.filter_options.min_length {
             if let Some(plain_text) = &item.plain_text {
@@ -475,6 +494,39 @@ impl App {
     pub fn is_item_read(&self, feed_idx: usize, item_idx: usize) -> bool {
         let item_id = self.get_item_id(feed_idx, item_idx);
         self.read_items.contains(&item_id)
+    }
+
+    // Toggle an item's starred status and return whether it's now starred
+    pub fn toggle_item_starred(&mut self, feed_idx: usize, item_idx: usize) -> Result<bool> {
+        let item_id = self.get_item_id(feed_idx, item_idx);
+        if !item_id.is_empty() {
+            let is_now_starred = if self.starred_items.contains(&item_id) {
+                self.starred_items.remove(&item_id);
+                false
+            } else {
+                self.starred_items.insert(item_id);
+                true
+            };
+            self.save_data()?;
+            Ok(is_now_starred)
+        } else {
+            Ok(false)
+        }
+    }
+
+    // Check if an item is starred
+    pub fn is_item_starred(&self, feed_idx: usize, item_idx: usize) -> bool {
+        let item_id = self.get_item_id(feed_idx, item_idx);
+        self.starred_items.contains(&item_id)
+    }
+
+    // Get starred items from dashboard_items for the Starred view
+    pub fn get_starred_dashboard_items(&self) -> Vec<(usize, usize)> {
+        self.dashboard_items
+            .iter()
+            .filter(|&&(feed_idx, item_idx)| self.is_item_starred(feed_idx, item_idx))
+            .cloned()
+            .collect()
     }
 
     pub fn update_dashboard(&mut self) {
@@ -786,6 +838,7 @@ impl App {
             self.filter_options.has_author.is_some(),
             self.filter_options.read_status.is_some(),
             self.filter_options.min_length.is_some(),
+            self.filter_options.starred_only.is_some(),
         ]
         .iter()
         .filter(|&&x| x)
@@ -849,6 +902,13 @@ impl App {
                 _ => "Custom",
             };
             parts.push(format!("Length: {}", length_str));
+        }
+
+        if let Some(is_starred) = self.filter_options.starred_only {
+            parts.push(format!(
+                "Starred: {}",
+                if is_starred { "Yes" } else { "No" }
+            ));
         }
 
         if parts.is_empty() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -245,17 +245,12 @@ fn handle_events(app: &mut App) -> Result<bool> {
                         }
                     }
                     KeyCode::Tab => {
-                        // Check if shift modifier is pressed
                         if key.modifiers.contains(event::KeyModifiers::SHIFT) {
-                            // With Shift+Tab, go from Feeds to Dashboard
-                            if matches!(app.view, View::FeedList) {
-                                app.view = View::Dashboard;
-                            }
+                            app.view = View::Starred;
+                            app.selected_item = None;
                         } else {
-                            // With Tab, go from Dashboard to Feeds
-                            if matches!(app.view, View::Dashboard) {
-                                app.view = View::FeedList;
-                            }
+                            app.view = View::FeedList;
+                            app.selected_item = None;
                         }
                     }
                     KeyCode::Char('a') => {
@@ -304,6 +299,31 @@ fn handle_events(app: &mut App) -> Result<bool> {
                                 "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
                             ) {
                                 app.error = Some(format!("Failed to add feed: {}", e));
+                            }
+                        }
+                    }
+                    KeyCode::Char('s') => {
+                        if let Some(selected) = app.selected_item {
+                            let (feed_idx, item_idx) =
+                                if app.is_searching && selected < app.filtered_items.len() {
+                                    app.filtered_items[selected]
+                                } else if selected < app.dashboard_items.len() {
+                                    app.dashboard_items[selected]
+                                } else {
+                                    return Ok(false);
+                                };
+                            match app.toggle_item_starred(feed_idx, item_idx) {
+                                Ok(is_now_starred) => {
+                                    app.success_message = Some(if is_now_starred {
+                                        "\u{2605} Starred".to_string()
+                                    } else {
+                                        "\u{2606} Unstarred".to_string()
+                                    });
+                                    app.success_message_time = Some(std::time::Instant::now());
+                                }
+                                Err(e) => {
+                                    app.error = Some(format!("Failed to toggle star: {}", e));
+                                }
                             }
                         }
                     }
@@ -414,7 +434,13 @@ fn handle_events(app: &mut App) -> Result<bool> {
                 View::FeedList => match key.code {
                     KeyCode::Char('q') => return Ok(true),
                     KeyCode::Tab => {
-                        app.view = View::Dashboard;
+                        if key.modifiers.contains(event::KeyModifiers::SHIFT) {
+                            app.view = View::Dashboard;
+                            app.selected_item = None;
+                        } else {
+                            app.view = View::Starred;
+                            app.selected_item = None;
+                        }
                     }
                     KeyCode::Char('a') => {
                         app.input.clear();
@@ -506,6 +532,25 @@ fn handle_events(app: &mut App) -> Result<bool> {
                         app.view = View::Dashboard;
                         app.selected_item = None;
                     }
+                    KeyCode::Char('s') => {
+                        if let Some(feed_idx) = app.selected_feed {
+                            if let Some(item_idx) = app.selected_item {
+                                match app.toggle_item_starred(feed_idx, item_idx) {
+                                    Ok(is_now_starred) => {
+                                        app.success_message = Some(if is_now_starred {
+                                            "\u{2605} Starred".to_string()
+                                        } else {
+                                            "\u{2606} Unstarred".to_string()
+                                        });
+                                        app.success_message_time = Some(std::time::Instant::now());
+                                    }
+                                    Err(e) => {
+                                        app.error = Some(format!("Failed to toggle star: {}", e));
+                                    }
+                                }
+                            }
+                        }
+                    }
                     KeyCode::Char('/') => {
                         app.input.clear();
                         app.input_mode = InputMode::SearchMode;
@@ -583,6 +628,25 @@ fn handle_events(app: &mut App) -> Result<bool> {
                 },
                 View::FeedItemDetail => match key.code {
                     KeyCode::Char('q') => return Ok(true),
+                    KeyCode::Char('s') => {
+                        if let Some(feed_idx) = app.selected_feed {
+                            if let Some(item_idx) = app.selected_item {
+                                match app.toggle_item_starred(feed_idx, item_idx) {
+                                    Ok(is_now_starred) => {
+                                        app.success_message = Some(if is_now_starred {
+                                            "\u{2605} Starred".to_string()
+                                        } else {
+                                            "\u{2606} Unstarred".to_string()
+                                        });
+                                        app.success_message_time = Some(std::time::Instant::now());
+                                    }
+                                    Err(e) => {
+                                        app.error = Some(format!("Failed to toggle star: {}", e));
+                                    }
+                                }
+                            }
+                        }
+                    }
                     KeyCode::Esc | KeyCode::Char('h') | KeyCode::Backspace => {
                         if app.is_searching {
                             // Return to search results
@@ -668,6 +732,129 @@ fn handle_events(app: &mut App) -> Result<bool> {
                                     }
                                 }
                             }
+                        }
+                    }
+                    _ => {}
+                },
+                View::Starred => match key.code {
+                    KeyCode::Char('q') => return Ok(true),
+                    KeyCode::Tab => {
+                        if key.modifiers.contains(event::KeyModifiers::SHIFT) {
+                            app.view = View::FeedList;
+                            app.selected_item = None;
+                        } else {
+                            app.view = View::Dashboard;
+                            app.selected_item = None;
+                        }
+                    }
+                    KeyCode::Esc | KeyCode::Char('h') => {
+                        app.view = View::Dashboard;
+                        app.selected_item = None;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if let Some(selected) = app.selected_item {
+                            if selected > 0 {
+                                app.selected_item = Some(selected - 1);
+                            }
+                        } else {
+                            let starred = app.get_starred_dashboard_items();
+                            if !starred.is_empty() {
+                                app.selected_item = Some(0);
+                            }
+                        }
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        let starred = app.get_starred_dashboard_items();
+                        if let Some(selected) = app.selected_item {
+                            if selected < starred.len().saturating_sub(1) {
+                                app.selected_item = Some(selected + 1);
+                            }
+                        } else if !starred.is_empty() {
+                            app.selected_item = Some(0);
+                        }
+                    }
+                    KeyCode::Enter => {
+                        let starred = app.get_starred_dashboard_items();
+                        if let Some(selected) = app.selected_item {
+                            if selected < starred.len() {
+                                let (feed_idx, item_idx) = starred[selected];
+                                app.selected_feed = Some(feed_idx);
+                                app.selected_item = Some(item_idx);
+                                app.view = View::FeedItemDetail;
+                                if let Err(e) = app.mark_item_as_read(feed_idx, item_idx) {
+                                    app.error = Some(format!("Failed to mark item as read: {}", e));
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char('s') => {
+                        let starred = app.get_starred_dashboard_items();
+                        if let Some(selected) = app.selected_item {
+                            if selected < starred.len() {
+                                let (feed_idx, item_idx) = starred[selected];
+                                match app.toggle_item_starred(feed_idx, item_idx) {
+                                    Ok(_) => {
+                                        app.success_message =
+                                            Some("\u{2606} Unstarred".to_string());
+                                        app.success_message_time = Some(std::time::Instant::now());
+                                        // Adjust selection after removal
+                                        let new_starred = app.get_starred_dashboard_items();
+                                        if new_starred.is_empty() {
+                                            app.selected_item = None;
+                                        } else if selected >= new_starred.len() {
+                                            app.selected_item = Some(new_starred.len() - 1);
+                                        }
+                                    }
+                                    Err(e) => {
+                                        app.error = Some(format!("Failed to unstar: {}", e));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char(' ') => {
+                        let starred = app.get_starred_dashboard_items();
+                        if let Some(selected) = app.selected_item {
+                            if selected < starred.len() {
+                                let (feed_idx, item_idx) = starred[selected];
+                                match app.toggle_item_read(feed_idx, item_idx) {
+                                    Ok(is_now_read) => {
+                                        app.success_message = Some(if is_now_read {
+                                            "\u{2713} Marked as read".to_string()
+                                        } else {
+                                            "\u{25CB} Marked as unread".to_string()
+                                        });
+                                        app.success_message_time = Some(std::time::Instant::now());
+                                    }
+                                    Err(e) => {
+                                        app.error =
+                                            Some(format!("Failed to toggle read status: {}", e));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Char('o') => {
+                        let starred = app.get_starred_dashboard_items();
+                        if let Some(selected) = app.selected_item {
+                            if selected < starred.len() {
+                                let (feed_idx, item_idx) = starred[selected];
+                                app.selected_feed = Some(feed_idx);
+                                app.selected_item = Some(item_idx);
+                                if let Err(e) = app.open_current_item_in_browser() {
+                                    app.error = Some(format!("Failed to open link: {}", e));
+                                }
+                                // Restore selection for starred view
+                                app.selected_item = Some(selected);
+                            }
+                        }
+                    }
+                    KeyCode::Char('t') => {
+                        if let Err(e) = app.toggle_theme() {
+                            app.error = Some(format!("Failed to toggle theme: {}", e));
+                        } else {
+                            app.success_message = Some("Theme toggled".to_string());
+                            app.success_message_time = Some(std::time::Instant::now());
                         }
                     }
                     _ => {}
@@ -883,6 +1070,15 @@ fn handle_events(app: &mut App) -> Result<bool> {
                     app.filter_options.read_status = match app.filter_options.read_status {
                         None => Some(true),        // Show read
                         Some(true) => Some(false), // Show unread
+                        Some(false) => None,       // Show all
+                    };
+                    app.apply_filters();
+                }
+                KeyCode::Char('s') => {
+                    // Cycle through starred filter
+                    app.filter_options.starred_only = match app.filter_options.starred_only {
+                        None => Some(true),        // Show starred
+                        Some(true) => Some(false), // Show unstarred
                         Some(false) => None,       // Show all
                     };
                     app.apply_filters();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -270,6 +270,7 @@ pub fn render<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         View::FeedItems => render_feed_items(f, app, chunks[1], &colors),
         View::FeedItemDetail => render_item_detail(f, app, chunks[1], &colors),
         View::CategoryManagement => render_category_management(f, app, chunks[1], &colors),
+        View::Starred => render_starred(f, app, chunks[1], &colors),
         View::Summary => render_summary(f, app, chunks[1], &colors),
     }
 
@@ -309,6 +310,7 @@ fn render_title_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors:
         "Items",
         "Detail",
         "Categories",
+        "Starred",
         "What's New",
     ];
     let selected_tab = match app.view {
@@ -317,7 +319,8 @@ fn render_title_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors:
         View::FeedItems => 2,
         View::FeedItemDetail => 3,
         View::CategoryManagement => 4,
-        View::Summary => 5,
+        View::Starred => 5,
+        View::Summary => 6,
     };
 
     // Theme-specific loading animation
@@ -630,6 +633,7 @@ fn render_dashboard<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect, col
             let date_str = item.formatted_date.as_deref().unwrap_or("Unknown date");
             let is_selected = app.selected_item == Some(idx);
             let is_read = app.is_item_read(feed_idx, item_idx);
+            let is_starred = app.is_item_starred(feed_idx, item_idx);
 
             // Create clearer visual group with theme-specific hierarchy
             ListItem::new(vec![
@@ -652,6 +656,10 @@ fn render_dashboard<B: Backend>(f: &mut Frame<B>, app: &mut App, area: Rect, col
                                 colors.text_secondary
                             })
                             .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        if is_starred { " \u{2605}" } else { "" },
+                        Style::default().fg(Color::Rgb(255, 215, 0)),
                     ),
                     Span::styled(
                         if is_read {
@@ -1160,6 +1168,9 @@ fn render_feed_items<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors
                 let is_read = app
                     .selected_feed
                     .is_some_and(|feed_idx| app.is_item_read(feed_idx, idx));
+                let is_starred = app
+                    .selected_feed
+                    .is_some_and(|feed_idx| app.is_item_starred(feed_idx, idx));
 
                 // Use cached plain_text to avoid HTML parsing per frame
                 let snippet = if let Some(plain_text) = &item.plain_text {
@@ -1201,6 +1212,10 @@ fn render_feed_items<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors
                                 } else {
                                     Modifier::empty()
                                 }),
+                        ),
+                        Span::styled(
+                            if is_starred { " \u{2605}" } else { "" },
+                            Style::default().fg(Color::Rgb(255, 215, 0)),
                         ),
                         Span::styled(
                             if is_read {
@@ -1464,6 +1479,151 @@ fn render_item_detail<B: Backend>(
     }
 }
 
+fn render_starred<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors: &ColorScheme) {
+    let starred_items = app.get_starred_dashboard_items();
+    let title = format!(" \u{2605} Starred Articles ({}) ", starred_items.len());
+
+    if starred_items.is_empty() {
+        let star_icon = if colors.border_normal == BorderType::Double {
+            "\u{2606}" // Dark: hollow star
+        } else {
+            "\u{2605}" // Light: filled star
+        };
+
+        let mut text = Text::default();
+        text.lines.push(Line::from(""));
+        text.lines.push(Line::from(Span::styled(
+            format!("       {}       ", star_icon),
+            Style::default().fg(Color::Rgb(255, 215, 0)),
+        )));
+        text.lines.push(Line::from(""));
+        text.lines.push(Line::from(Span::styled(
+            "No starred articles yet",
+            Style::default()
+                .fg(colors.text)
+                .add_modifier(Modifier::BOLD),
+        )));
+        text.lines.push(Line::from(""));
+        text.lines.push(Line::from(Span::styled(
+            "Press s on any article to star it",
+            Style::default().fg(colors.highlight),
+        )));
+
+        let paragraph = Paragraph::new(text).alignment(Alignment::Center).block(
+            Block::default()
+                .title(title)
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_type(colors.border_normal)
+                .border_style(Style::default().fg(colors.border))
+                .style(Style::default().bg(colors.surface))
+                .padding(Padding::new(2, 2, 2, 2)),
+        );
+
+        f.render_widget(paragraph, area);
+        return;
+    }
+
+    let arrow = colors.get_arrow_right();
+    let success_icon = colors.get_icon_success();
+    let items: Vec<ListItem> = starred_items
+        .iter()
+        .enumerate()
+        .map(|(idx, &(feed_idx, item_idx))| {
+            let feed = &app.feeds[feed_idx];
+            let item = &feed.items[item_idx];
+            let date_str = item.formatted_date.as_deref().unwrap_or("Unknown date");
+            let is_selected = app.selected_item == Some(idx);
+            let is_read = app.is_item_read(feed_idx, item_idx);
+
+            ListItem::new(vec![
+                Line::from(vec![
+                    Span::styled(
+                        if is_selected {
+                            format!("{} ", arrow)
+                        } else {
+                            "  ".to_string()
+                        },
+                        Style::default().fg(colors.highlight),
+                    ),
+                    Span::styled(
+                        feed.title.to_string(),
+                        Style::default()
+                            .fg(if is_selected {
+                                colors.secondary
+                            } else {
+                                colors.text_secondary
+                            })
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" \u{2605}", Style::default().fg(Color::Rgb(255, 215, 0))),
+                    Span::styled(
+                        if is_read {
+                            format!(" {}", success_icon)
+                        } else {
+                            "".to_string()
+                        },
+                        Style::default().fg(colors.success),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(
+                        &item.title,
+                        Style::default()
+                            .fg(if is_selected {
+                                colors.text
+                            } else if is_read {
+                                colors.text_secondary
+                            } else {
+                                colors.text
+                            })
+                            .add_modifier(if is_selected {
+                                Modifier::BOLD
+                            } else {
+                                Modifier::empty()
+                            }),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(date_str, Style::default().fg(colors.muted)),
+                ]),
+                Line::from(""),
+            ])
+            .style(Style::default().fg(colors.text).bg(if is_selected {
+                colors.selected_bg
+            } else {
+                colors.background
+            }))
+        })
+        .collect();
+
+    let starred_list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .title_alignment(Alignment::Center)
+                .borders(Borders::ALL)
+                .border_type(colors.border_normal)
+                .border_style(Style::default().fg(colors.border))
+                .style(Style::default().bg(colors.surface))
+                .padding(Padding::new(2, 1, 1, 1)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(colors.selected_bg)
+                .fg(colors.highlight)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("");
+
+    let mut state = ListState::default();
+    state.select(app.selected_item);
+
+    f.render_stateful_widget(starred_list, area, &mut state);
+}
+
 fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors: &ColorScheme) {
     // Match on the input mode and view to determine the help text and style
     let (help_text, _style) = match app.input_mode {
@@ -1473,7 +1633,7 @@ fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors: 
                     if app.feeds.is_empty() {
                         "a: Add feed | t: Theme | q: Quit | CTRL+C: Manage categories"
                     } else {
-                        "↑/↓: Navigate | ENTER: View | Space: Toggle read | p: Preview | a: Add feed | r: Refresh | f: Filter | /: Search | t: Theme | q: Quit"
+                        "\u{2191}/\u{2193}: Navigate | ENTER: View | s: Star | Space: Toggle read | p: Preview | a: Add | r: Refresh | f: Filter | /: Search | t: Theme | q: Quit"
                     }
                 }
                 View::FeedList => {
@@ -1487,10 +1647,13 @@ fn render_help_bar<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect, colors: 
                     "n: New category | e: Edit | d: Delete | SPACE: Toggle feeds | c: Add selected feed | t: Theme | ESC/q: Back"
                 }
                 View::FeedItems => {
-                    "h/esc: back | home: dashboard | enter: view | Space: Toggle read | o: open | /: search | t: theme | q: quit"
+                    "h/esc: back | home: dashboard | enter: view | s: Star | Space: Toggle read | o: open | /: search | t: theme | q: quit"
                 }
                 View::FeedItemDetail => {
-                    "h/esc: back | home: dashboard | ↑/↓: scroll | PgUp/PgDn: fast | Space: Toggle read | o: open | t: theme | q: quit"
+                    "h/esc: back | home: dashboard | \u{2191}/\u{2193}: scroll | PgUp/PgDn: fast | s: Star | Space: Toggle read | o: open | t: theme | q: quit"
+                }
+                View::Starred => {
+                    "\u{2191}/\u{2193}: Navigate | ENTER: View | s: Unstar | Space: Toggle read | o: Open | Tab: Switch view | q: Quit"
                 }
                 View::Summary => "Press any key to continue to Dashboard | q: Quit"
             };
@@ -1881,6 +2044,25 @@ fn render_filter_modal<B: Backend>(f: &mut Frame<B>, app: &App, colors: &ColorSc
         ),
     ]));
 
+    // Starred filter
+    let starred_status = match app.filter_options.starred_only {
+        Some(true) => "[Starred]",
+        Some(false) => "[Not starred]",
+        None => "[Off]",
+    };
+
+    text.push(Line::from(vec![
+        Span::styled("  s - Starred: ", Style::default().fg(colors.text)),
+        Span::styled(
+            starred_status,
+            Style::default().fg(if app.filter_options.starred_only.is_some() {
+                colors.highlight
+            } else {
+                colors.muted
+            }),
+        ),
+    ]));
+
     // Clear filters option
     text.push(Line::from(""));
     text.push(Line::from(vec![
@@ -1896,7 +2078,7 @@ fn render_filter_modal<B: Backend>(f: &mut Frame<B>, app: &App, colors: &ColorSc
 
     text.push(Line::from(vec![Span::styled(
         format!(
-            "  Active Filters: {}/5  |  Showing: {}/{} items",
+            "  Active Filters: {}/6  |  Showing: {}/{} items",
             active_count, filtered_count, total_count
         ),
         Style::default().fg(colors.muted),


### PR DESCRIPTION
Allow users to star articles with 's' from Dashboard, FeedItems, and FeedItemDetail views. Starred status persists across sessions in feedr_data.json. Adds a dedicated Starred view accessible via Tab cycling, star indicators in item lists, and a starred filter option in the filter modal.