### PR TITLE
fix(summary): stabilize "What's New" feed order with name tie-break

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1429,7 +1429,7 @@ impl App {
             .into_iter()
             .map(|(name, count)| (name.to_string(), count))
             .collect();
-        feeds_with_counts.sort_by(|a, b| b.1.cmp(&a.1));
+        feeds_with_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
         (total, feeds_with_counts)
     }
@@ -1683,6 +1683,39 @@ mod tests {
         assert_eq!(feeds[0].1, 2);
         assert_eq!(feeds[1].0, "Feed Two");
         assert_eq!(feeds[1].1, 1);
+    }
+
+    #[test]
+    fn test_get_summary_stats_tie_break_by_name() {
+        let mut app = make_test_app();
+        // Add a third feed whose name sorts before "Feed Two" but ties on count
+        app.feeds.push(Feed {
+            url: "https://example.com/feed3".to_string(),
+            title: "Alpha Feed".to_string(),
+            title_lower: "alpha feed".to_string(),
+            items: vec![FeedItem {
+                title: "Alpha New".to_string(),
+                title_lower: "alpha new".to_string(),
+                link: Some("https://example.com/alpha".to_string()),
+                description: Some("Alpha content".to_string()),
+                pub_date: None,
+                author: None,
+                formatted_date: None,
+                parsed_date: Some(Utc::now() - chrono::Duration::hours(3)),
+                plain_text: Some("Alpha content".to_string()),
+            }],
+        });
+        app.last_session_time = Some(Utc::now() - chrono::Duration::days(365));
+
+        // Run twice — order must be identical across calls regardless of HashMap iteration.
+        let (_, first) = app.get_summary_stats();
+        let (_, second) = app.get_summary_stats();
+        assert_eq!(first, second);
+
+        // Feed One leads on count; "Alpha Feed" beats "Feed Two" alphabetically on the tie.
+        assert_eq!(first[0], ("Feed One".to_string(), 2));
+        assert_eq!(first[1], ("Alpha Feed".to_string(), 1));
+        assert_eq!(first[2], ("Feed Two".to_string(), 1));
     }
 
     #[test]

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -415,6 +415,7 @@ pub fn run() -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::collapsible_match)]
 fn run_editor(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     editor: &mut ConfigEditor,

--- a/src/events.rs
+++ b/src/events.rs
@@ -105,6 +105,11 @@ pub(crate) fn handle_events(app: &mut App) -> Result<bool> {
     Ok(false)
 }
 
+// Inner `if` blocks inside match arms are intentional. Collapsing them into match
+// guards (as `clippy::collapsible_match` suggests) would change behavior for the
+// hardcoded `1`/`2`/`3` demo-feed shortcuts, since unmatched arms fall through to
+// the configurable-keybinding guard arms.
+#[allow(clippy::collapsible_match)]
 pub(crate) fn handle_key_event(app: &mut App, key: crossterm::event::KeyEvent) -> Result<bool> {
     if matches!(key.kind, KeyEventKind::Release) {
         return Ok(false);
@@ -1191,6 +1196,7 @@ pub(crate) fn handle_key_event(app: &mut App, key: crossterm::event::KeyEvent) -
     Ok(false)
 }
 
+#[allow(clippy::collapsible_match)]
 fn handle_mouse_event(app: &mut App, mouse: MouseEvent) -> Result<bool> {
     // Dismiss overlays on any click
     if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {


### PR DESCRIPTION
Closes #37

## Summary
- The "What's New since last visit" summary was sorting feeds by new-item count only, which is not a total order. Two feeds tied on count came out in whatever order Rust's `HashMap` happened to iterate that frame; since the summary re-renders on every tick, tied feeds visibly shuffled several times per second.
- Fix is one line in `get_summary_stats`: chain a name tie-breaker after the count comparison (`b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0))`) — count descending, then name ascending. Preserves the existing UX (highest count first) and gives ties a stable, intuitive order.
- The reporter's suggested snippet (`sort_by_key(|(name, count)| (count, name))`) would have inverted the dominant ordering — the `then_with` form keeps it descending and survives the existing sorting test.

## Clippy cleanup
- The repo had 16 pre-existing `clippy::collapsible_match` warnings in `src/events.rs` and `src/config_tui.rs` blocking `-D warnings`. Most are technically safe to collapse, but the demo-feed shortcuts (`KeyCode::Char('1'/'2'/'3')`) cannot be — CLAUDE.md notes those number keys are intentionally hardcoded as no-ops, and collapsing would let user-configured bindings on those keys fire when feeds are present.
- Clippy itself classifies the suggestions as `MaybeIncorrect` (so `cargo clippy --fix` skips them). Added function-scoped `#[allow(clippy::collapsible_match)]` on `handle_key_event`, `handle_mouse_event`, and `run_editor`, with a comment explaining the rationale on the most-affected handler.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — 81 unit + 4 integration tests pass, including the new `test_get_summary_stats_tie_break_by_name` which calls `get_summary_stats` twice and asserts the output is identical (regression guard against HashMap-induced flicker)
- [ ] Manual verification: open the "What's New" screen with two or more feeds tied on new-item count and confirm the order no longer shifts between frames